### PR TITLE
export ignore README files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@
 /.php_cs            export-ignore
 /.travis.yml        export-ignore
 /Makefile           export-ignore
+/[rR][eE][aA][dD][mM][eE]* export-ignore


### PR DESCRIPTION
Do we really need a bunch of README files hanging out in the vendor directory?

Also, I'm sorry about wrecking the neat columnar spacing. I'd be happy to push another commit that evens them all out, but I wanted you to have a clean diff for this change.

Thanks!