### PR TITLE
Fix: Add example to pass build

### DIFF
--- a/src/Example.php
+++ b/src/Example.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2019 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/repository
+ */
+
+namespace Localheinz\Repository;
+
+final class Example
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    private function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public static function fromName(string $name): self
+    {
+        return new self($name);
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+}

--- a/test/Unit/ExampleTest.php
+++ b/test/Unit/ExampleTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2019 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/repository
+ */
+
+namespace Localheinz\Repository\Test\Unit;
+
+use Localheinz\Repository\Example;
+use Localheinz\Test\Util\Helper;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ *
+ * @covers \Localheinz\Repository\Example
+ */
+final class ExampleTest extends Framework\TestCase
+{
+    use Helper;
+
+    public function testFromNameReturnsExample(): void
+    {
+        $name = $this->faker()->sentence;
+
+        $example = Example::fromName($name);
+
+        self::assertSame($name, $example->name());
+    }
+}


### PR DESCRIPTION
This PR

* [x] adds an `Example` class along with an `ExampleTest` to ensure the build passes (`infection/infection` currently fails when code coverage was not generated)